### PR TITLE
Chore/#41 nginx에서 정적파일 serving하도록 연동 

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,20 @@
 services:
-  fastapi:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./Frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "5173:5173"
+    volumes:
+      - build_folder:/frontend/dist
+    networks:
+      - teamM
+    tty: true
+    stdin_open: true
+
+  backend:
+    container_name: backend
     build:
       context: ./Backend
       dockerfile: Dockerfile
@@ -16,7 +31,6 @@ services:
       always
     env_file:
       - .env
-    container_name: teamM
     tty: true
     networks:
       - teamM
@@ -181,9 +195,11 @@ services:
     ports:
       - 80:80
     volumes:
+      - build_folder:/var/www/frontend
       - ./nginx/log:/var/log/nginx  # 로그 디렉토리 마운트
     depends_on:
-      - fastapi
+      - frontend
+      - backend
     networks:
       - teamM
 
@@ -202,7 +218,7 @@ services:
 volumes:
   postgres_data:
   esdata:
-
+  build_folder:
 networks:
   teamM:
     driver: bridge

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,8 +23,6 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-      postgresql:
-        condition: service_started
       redis:
         condition: service_started
     restart:
@@ -50,28 +48,6 @@ services:
         - "--collector.filesystem.ignored-mount-points"
         - "^/(rootfs/)?(dev|etc|host|proc|run|sys|volume1)($$|/)"
     restart: unless-stopped
-    networks:
-      - teamM
-
-  postgresql:
-    image: postgres:13
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    env_file:
-      - .env
-    ports:
-      - "5432:5432"
-    networks:
-      - teamM
-
-  postgres-exporter:
-    image: wrouesnel/postgres_exporter:latest
-    container_name: postgres_exporter
-    ports:
-      - "9187:9187"
-    environment:
-      - DATA_SOURCE_NAME=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable
-    platform: linux/amd64
     networks:
       - teamM
 
@@ -216,7 +192,6 @@ services:
       - teamM
 
 volumes:
-  postgres_data:
   esdata:
   build_folder:
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,20 @@
-version: '3.8'
-
 services:
-  fastapi:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./Frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "5173:5173"
+    volumes:
+      - build_folder:/frontend/dist
+    networks:
+      - teamM
+    tty: true
+    stdin_open: true
+
+  backend:
+    container_name: backend
     build:
       context: ./Backend
       dockerfile: Dockerfile
@@ -17,7 +30,6 @@ services:
     restart: always
     env_file:
       - .env
-    container_name: teamM
     tty: true
     networks:
       - teamM
@@ -68,34 +80,18 @@ services:
       context: ./nginx
     ports:
       - "80:80"
-    #    volumes:
-    #      - ./nginx/nginx.conf:/etc/nginx/nginx.conf  # Nginx 설정 파일 마운트
-    #      - ./nginx/log:/var/log/nginx  # 로그 디렉토리 마운트
-
-    depends_on:
-      - fastapi
-      - frontend
-    networks:
-      - teamM
-
-  frontend:
-    container_name: frontend
-    build:
-      context: ./Frontend
-      dockerfile: Dockerfile.prod
-    ports:
-      - "5173:5173"
     volumes:
-      - ./Frontend:/app
+      - build_folder:/var/www/frontend
+    depends_on:
+      - frontend
+      - backend
     networks:
       - teamM
-    tty: true
-    stdin_open: true
 
 volumes:
   postgres_data:
   esdata:
-
+  build_folder:
 networks:
   teamM:
     driver: bridge

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,37 +1,31 @@
-user  nginx;
-worker_processes  auto;
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
 events {
-    worker_connections  1024;
+    worker_connections 1024;
 }
 
 http {
+    # 백엔드 upstream 설정
+    upstream backend {
+        server backend:8000;
+    }
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # 백엔드 upstream 설정
-    upstream backend {
-        server fastapi:8000;
-    }
-
-#     upstream frontend {
-#         server frontend:5173;
-#     }
-
     server {
         listen 80;
-        charset utf-8;
 
         # frontend
-        # location / {
-        #     proxy_pass http://frontend;
-        # }
+        location / {
+            root /var/www/frontend;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
 
         # backend
         location /api/ {
             proxy_pass  http://backend;
         }
+
         location /metrics {
             stub_status;
             allow all;  # 모든 IP 허용 (보안상 특정 IP로 제한할 수 있음)
@@ -45,5 +39,4 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
-    # include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## 💻구현 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

도커 컴포즈로 frontend 컨테이너를 띄워서 빌드한 다음 nginx 컨테이너에 정적파일을 마운트하여 사용자가 루트 엔드포인트로 진입하는 경우, 정적파일이 서빙되도록 하였습니다. 또한 API 호출하는 부분도 테스트 완료 했습니다.
<br><br>
## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

docker-compose-prod.yml과 docker-compose.yml 파일

<br><br>
## #️⃣연관된 이슈
> 아래에 {이슈번호}를 작성해주세요
<br>
close #41

<br><br>
## ✅Check List
- [ ] docker-compose-prod.yml은 실행시켜도 postgresql 컨테이너가 없어서 backend 컨테이너가 실행되지 않아 배포 바로 진행할 계획입니다.
- [x] #41 
