### PR TITLE
[#46] Chore: nginx.conf 수정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,13 @@ http {
             proxy_pass  http://backend;
         }
 
+        location /ws/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+    	    proxy_pass  http://backend;
+    	}
+
         location /metrics {
             stub_status;
             allow all;  # 모든 IP 허용 (보안상 특정 IP로 제한할 수 있음)


### PR DESCRIPTION
## 💻구현 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

채팅이 되지 않는 오류 발생.
이유: 배포 환경에서 nginx가 backend로 라우팅시키지 않은 것으로 확인하여 /ws/ 엔드포인트 추가 및 ugrade 헤더와 connection 추가

<br><br>
## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

실제 사이트에 들어가서 채팅 기능 확인
<br><br>
## #️⃣연관된 이슈
> 아래에 {이슈번호}를 작성해주세요
<br>
close #46 

<br><br>
## ✅Check List
- [x] PR 제목 규칙
- [x] /ws/ 엔드포인트 추가 및 ugrade 헤더와 connection 추가
- [x] #46 
